### PR TITLE
Update copyright notice

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,13 @@ project adheres to https://semver.org/[Semantic Versioning].
 
 toc::[]
 
+== {compare-url}/v0.2.1\...HEAD[Unreleased]
+
+=== Changed
+
+* Change the comment header to the format recommended by the REUSE
+  Specification ({pull-request-url}/6[#6])
+
 == {compare-url}/v0.2.0\...v0.2.1[0.2.1] - 2023-06-09
 
 === Changed

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2023 Shun Sakai
-#
 
 using Documenter, Sysexits
 

--- a/example/isascii.jl
+++ b/example/isascii.jl
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2023 Shun Sakai
-#
 
 import Sysexits
 

--- a/justfile
+++ b/justfile
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2023 Shun Sakai
-#
 
 # Run tests
 test:

--- a/src/Sysexits.jl
+++ b/src/Sysexits.jl
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2023 Shun Sakai
-#
 
 """
 The `Sysexits` module provides the system exit code constants as defined by

--- a/src/exitcode.jl
+++ b/src/exitcode.jl
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2023 Shun Sakai
-#
 
 """
 The `ExitCode` type represents the system exit code constants as defined by

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,6 @@
+# SPDX-FileCopyrightText: 2023 Shun Sakai
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-#
-# Copyright (C) 2023 Shun Sakai
-#
 
 using Documenter, Sysexits, Test
 


### PR DESCRIPTION
Change the comment header to the format recommended by the REUSE Specification.[^1]

[^1]: https://reuse.software/spec/#comment-headers